### PR TITLE
Addin exception to always accept Nomis Daily Quest

### DIFF
--- a/Config.lua
+++ b/Config.lua
@@ -8,6 +8,7 @@ local defaults = {
 	reverse = false,
 	share = false,
 	withered = true,
+	nomi = true,
 }
 
 local isBetaClient = select(4, GetBuildInfo()) >= 70000
@@ -75,6 +76,12 @@ Options:Initialize(function(self)
 	Withered:SetPoint('TOPLEFT', Reverse, 'BOTTOMLEFT', -24, -8)
 	Withered:SetText(L['Disable while doing the withered training scenario in Suramar'])
 	Withered:SetNewFeature(true)
+
+	local Nomi = self:CreateCheckButton('nomi')
+	Nomi:SetPoint('TOPLEFT', Withered, 'BOTTOMLEFT', 0, -8)
+	Nomi:SetText(L['Always accept and complete Nomi\'s daily quest, despite being low-level'])
+	Nomi:SetNewFeature(true)
+
 end)
 
 local defaultBlacklist = {

--- a/QuickQuest.lua
+++ b/QuickQuest.lua
@@ -132,7 +132,7 @@ QuickQuest:Register('GOSSIP_SHOW', function()
 	if(available > 0) then
 		for index = 1, available do
 			local _, _, trivial, ignored = GetAvailableGossipQuestInfo(index)
-			if((not trivial and not ignored) or IsTrackingHidden()) then
+			if((not trivial and not ignored) or IsTrackingHidden()) or (npcID == 64337 and QuickQuestDB.nomi) then
 				SelectGossipAvailableQuest(index)
 			end
 		end


### PR DESCRIPTION
Fixes #20.

Changes proposed in this pull request:
Addin exception to always accept Nomis Daily Quest from the Cooking School Bell.