### PR TITLE
Added blocklist by title / questID

### DIFF
--- a/Addon.lua
+++ b/Addon.lua
@@ -38,8 +38,7 @@ local function IsQuestIgnored( questID )
 	end
 
 	local title = C_QuestLog.GetTitleForQuestID(questID)
-
-	for _, titleOrQuestID in ipairs(ns.db.profile.blocklist.title) do
+	for _, titleOrQuestID in next, ns.db.profile.blocklist.title do
 		if titleOrQuestID == tostring(questID) or (title or ""):lower():find(titleOrQuestID:lower()) then
 			return true
 		end

--- a/config/OptionsBlocklist.lua
+++ b/config/OptionsBlocklist.lua
@@ -222,9 +222,81 @@ local function CreateNPCBlocklistOptions()
 	end)
 end
 
+local function CreateTitleBlocklistOptions()
+	local panel = CreateOptionsPanel('TitleBlocklist',
+		L['Title Blocklist'],
+		L['Quests with titles that partially match or IDs that exactly match entries from this list will not be automated.'],
+		L['Block Title'])
+
+	local function OnRemove(self)
+		for i, title in ipairs(ns.db.profile.blocklist.title) do
+			if title == self.title then
+				tremove(ns.db.profile.blocklist.title, i)
+			end
+		end
+	end
+	
+	local titles = ns.db.profile.blocklist.title
+
+	local function AddButton(pool, title)
+		if title:find("^%s*$") then
+			print(addonName .. ': Invalid quest title or ID')
+		else
+			local button = pool:CreateButton()
+			button.title = title
+			button.OnRemove = OnRemove
+
+			if not button.text then
+				local text = button:CreateFontString('$parentText', 'ARTWORK', 'GameFontNormal')
+				text:SetPoint('LEFT', button, 'LEFT', 5, 0)
+				button.text = text
+				
+				local frame = CreateFrame('Frame', nil, button, BackdropTemplateMixin and 'BackdropTemplate')
+				frame:SetPoint('TOPLEFT', -2, 2)
+				frame:SetPoint('BOTTOMRIGHT', 2, -2)
+				frame:SetBackdrop(BACKDROP)
+				frame:SetBackdropColor(0, 0, 0, 0)
+				frame:SetBackdropBorderColor(0.5, 0.5, 0.5)
+				frame:SetFrameLevel(button:GetFrameLevel() + 1)
+				button.frame = frame
+			
+				button.remove:SetFrameLevel(frame:GetFrameLevel() + 1)
+			end
+			
+			button.text:SetText(title)
+			
+			pool:Reposition()
+
+			-- inject into db
+			if not tContains(titles, title) then
+				tinsert(titles, title)
+			end
+		end
+	end
+
+	local offset = 16
+	local spacing = 4
+	local width = 500 -- big enough to only have 1 column
+	local height = 18
+	local titlePool = ns.CreateButtonPool(panel.container, offset, width, height, spacing)
+	titlePool:SetSortField('title')
+
+	for _, title in ipairs(titles) do
+		AddButton(titlePool, title)
+	end
+
+	panel.button:SetScript('OnClick', function()
+		StaticPopup_Show(addonName .. 'TitleBlocklistPopup', nil, nil, {
+			callback = AddButton,
+			pool = titlePool,
+		})
+	end)
+end
+
 function ns.CreateBlocklistOptions()
 	ns.CreateBlocklistOptions = nop -- we only want to run this once
 
 	CreateItemBlocklistOptions()
 	CreateNPCBlocklistOptions()
+	CreateTitleBlocklistOptions()
 end

--- a/config/OptionsBlocklist.lua
+++ b/config/OptionsBlocklist.lua
@@ -229,14 +229,12 @@ local function CreateTitleBlocklistOptions()
 		L['Block Title'])
 
 	local function OnRemove(self)
-		for i, title in ipairs(ns.db.profile.blocklist.title) do
+		for index, title in next, ns.db.profile.blocklist.title do
 			if title == self.title then
-				tremove(ns.db.profile.blocklist.title, i)
+				tremove(ns.db.profile.blocklist.title, index)
 			end
 		end
 	end
-	
-	local titles = ns.db.profile.blocklist.title
 
 	local function AddButton(pool, title)
 		if title:find("^%s*$") then
@@ -268,8 +266,8 @@ local function CreateTitleBlocklistOptions()
 			pool:Reposition()
 
 			-- inject into db
-			if not tContains(titles, title) then
-				tinsert(titles, title)
+			if not tContains(ns.db.profile.blocklist.title, title) then
+				tinsert(ns.db.profile.blocklist.title, title)
 			end
 		end
 	end
@@ -281,7 +279,7 @@ local function CreateTitleBlocklistOptions()
 	local titlePool = ns.CreateButtonPool(panel.container, offset, width, height, spacing)
 	titlePool:SetSortField('title')
 
-	for _, title in ipairs(titles) do
+	for _, title in next, ns.db.profile.blocklist.title do
 		AddButton(titlePool, title)
 	end
 

--- a/config/OptionsPopups.lua
+++ b/config/OptionsPopups.lua
@@ -6,8 +6,8 @@ StaticPopupDialogs[addonName .. 'ItemBlocklistPopup'] = {
 	button1 = L['Accept'],
 	button2 = L['Cancel'],
 	hasEditBox = true,
-	EditBoxOnEnterPressed = function(self, data)
-		data.callback(data.pool, tonumber(strtrim(self:GetText())))
+	EditBoxOnEnterPressed = function(self)
+		self.data.callback(self.data.pool, tonumber(strtrim(self.editBox:GetText())))
 		self:GetParent():Hide()
 	end,
 	EditBoxOnEscapePressed = function(self)
@@ -51,8 +51,8 @@ StaticPopupDialogs[addonName .. 'NPCBlocklistPopup'] = {
 	button2 = L['Cancel'],
 	button3 = L['Target'],
 	hasEditBox = true,
-	EditBoxOnEnterPressed = function(self, data)
-		data.callback(data.pool, tonumber(strtrim(self:GetText())))
+	EditBoxOnEnterPressed = function(self)
+		self.data.callback(self.data.pool, tonumber(strtrim(self.editBox:GetText())))
 		self:GetParent():Hide()
 	end,
 	EditBoxOnEscapePressed = function(self)

--- a/config/OptionsPopups.lua
+++ b/config/OptionsPopups.lua
@@ -6,8 +6,8 @@ StaticPopupDialogs[addonName .. 'ItemBlocklistPopup'] = {
 	button1 = L['Accept'],
 	button2 = L['Cancel'],
 	hasEditBox = true,
-	EditBoxOnEnterPressed = function(self)
-		self.data.callback(self.data.pool, tonumber(strtrim(self.editBox:GetText())))
+	EditBoxOnEnterPressed = function(self, data)
+		data.callback(data.pool, tonumber(strtrim(self:GetText())))
 		self:GetParent():Hide()
 	end,
 	EditBoxOnEscapePressed = function(self)
@@ -51,8 +51,8 @@ StaticPopupDialogs[addonName .. 'NPCBlocklistPopup'] = {
 	button2 = L['Cancel'],
 	button3 = L['Target'],
 	hasEditBox = true,
-	EditBoxOnEnterPressed = function(self)
-		self.data.callback(self.data.pool, tonumber(strtrim(self.editBox:GetText())))
+	EditBoxOnEnterPressed = function(self, data)
+		data.callback(data.pool, tonumber(strtrim(self:GetText())))
 		self:GetParent():Hide()
 	end,
 	EditBoxOnEscapePressed = function(self)
@@ -63,6 +63,31 @@ StaticPopupDialogs[addonName .. 'NPCBlocklistPopup'] = {
 	end,
 	OnAlt = function(self)
 		self.data.callback(self.data.pool, ns.GetNPCID('target'))
+	end,
+	OnShow = function(self)
+		self.editBox:SetFocus()
+	end,
+	OnHide = function(self)
+		self.editBox:SetText('')
+	end,
+	hideOnEscape = true,
+	timeout = 0,
+}
+
+StaticPopupDialogs[addonName .. 'TitleBlocklistPopup'] = {
+	text = L['Block a quest by title or ID'],
+	button1 = L['Accept'],
+	button2 = L['Cancel'],
+	hasEditBox = true,
+	EditBoxOnEnterPressed = function(self, data)
+		data.callback(data.pool, strtrim(self:GetText()))
+		self:GetParent():Hide()
+	end,
+	EditBoxOnEscapePressed = function(self)
+		self:GetParent():Hide()
+	end,
+	OnAccept = function(self)
+		self.data.callback(self.data.pool, strtrim(self.editBox:GetText()))
 	end,
 	OnShow = function(self)
 		self.editBox:SetFocus()

--- a/config/SavedVariables.lua
+++ b/config/SavedVariables.lua
@@ -157,10 +157,6 @@ ns.EventHandler:Register('ADDON_LOADED', function(...)
 			QuickQuestBlacklistDB = nil
 		end
 
-		if not ns.db.profile.blocklist.title then
-			ns.db.profile.blocklist.title = {}
-		end
-
 		return true -- unregister
 	end
 end)

--- a/config/SavedVariables.lua
+++ b/config/SavedVariables.lua
@@ -106,6 +106,7 @@ local defaults = {
 				-- misc
 				[143925] = true, -- Dark Iron Mole Machine (Dark Iron Dwarf racial)
 			},
+			title = {}
 		},
 	},
 }
@@ -154,6 +155,10 @@ ns.EventHandler:Register('ADDON_LOADED', function(...)
 			end
 
 			QuickQuestBlacklistDB = nil
+		end
+
+		if not ns.db.profile.blocklist.title then
+			ns.db.profile.blocklist.title = {}
 		end
 
 		return true -- unregister

--- a/locale/deDE.lua
+++ b/locale/deDE.lua
@@ -10,13 +10,16 @@ L['Reverse the behaviour of the modifier key'] = 'Verhalten der Moditfikatortast
 
 -- L['Item Blocklist'] = '' -- MISSING!
 -- L['NPC Blocklist'] = '' -- MISSING!
+-- L['Title Blocklist'] = '' -- MISSING
 -- L['Block Item'] = '' -- MISSING!
 -- L['Block NPC'] = '' -- MISSING!
+-- L['Block Title']) = '' --MISSING!
 -- L['Quests containing items in this list will not be automated.'] = '' -- MISSING!
 -- L['Quests and dialogue from NPCs in this list will not be automated.'] = '' -- MISSING!
 
 -- L['Block a new item by ID'] = '' -- MISSING!
 -- L['Block a new NPC by ID'] = '' -- MISSING!
+-- L['Quests with titles that partially match or IDs that exactly match entries from this list will not be automated.'] = '' -- MISSING!
 
 L['ALT key'] = ALT_KEY
 L['CTRL key'] = CTRL_KEY

--- a/locale/esES.lua
+++ b/locale/esES.lua
@@ -10,13 +10,16 @@ L['Reverse the behaviour of the modifier key'] = 'Revertir el funcionamiento de 
 
 -- L['Item Blocklist'] = '' -- MISSING!
 -- L['NPC Blocklist'] = '' -- MISSING!
+-- L['Title Blocklist'] = '' -- MISSING
 -- L['Block Item'] = '' -- MISSING!
 -- L['Block NPC'] = '' -- MISSING!
+-- L['Block Title']) = '' --MISSING!
 -- L['Quests containing items in this list will not be automated.'] = '' -- MISSING!
 -- L['Quests and dialogue from NPCs in this list will not be automated.'] = '' -- MISSING!
 
 -- L['Block a new item by ID'] = '' -- MISSING!
 -- L['Block a new NPC by ID'] = '' -- MISSING!
+-- L['Quests with titles that partially match or IDs that exactly match entries from this list will not be automated.'] = '' -- MISSING!
 
 L['ALT key'] = ALT_KEY
 L['CTRL key'] = CTRL_KEY

--- a/locale/esMX.lua
+++ b/locale/esMX.lua
@@ -10,13 +10,16 @@ local L = select(2, ...).L('esMX')
 
 -- L['Item Blocklist'] = '' -- MISSING!
 -- L['NPC Blocklist'] = '' -- MISSING!
+-- L['Title Blocklist'] = '' -- MISSING
 -- L['Block Item'] = '' -- MISSING!
 -- L['Block NPC'] = '' -- MISSING!
+-- L['Block Title']) = '' --MISSING!
 -- L['Quests containing items in this list will not be automated.'] = '' -- MISSING!
 -- L['Quests and dialogue from NPCs in this list will not be automated.'] = '' -- MISSING!
 
 -- L['Block a new item by ID'] = '' -- MISSING!
 -- L['Block a new NPC by ID'] = '' -- MISSING!
+-- L['Quests with titles that partially match or IDs that exactly match entries from this list will not be automated.'] = '' -- MISSING!
 
 L['ALT key'] = ALT_KEY
 L['CTRL key'] = CTRL_KEY

--- a/locale/frFR.lua
+++ b/locale/frFR.lua
@@ -10,13 +10,16 @@ L['Reverse the behaviour of the modifier key'] = 'Inverser le comportement de la
 
 -- L['Item Blocklist'] = '' -- MISSING!
 -- L['NPC Blocklist'] = '' -- MISSING!
+-- L['Title Blocklist'] = '' -- MISSING
 -- L['Block Item'] = '' -- MISSING!
 -- L['Block NPC'] = '' -- MISSING!
+-- L['Block Title']) = '' --MISSING!
 -- L['Quests containing items in this list will not be automated.'] = '' -- MISSING!
 -- L['Quests and dialogue from NPCs in this list will not be automated.'] = '' -- MISSING!
 
 -- L['Block a new item by ID'] = '' -- MISSING!
 -- L['Block a new NPC by ID'] = '' -- MISSING!
+-- L['Quests with titles that partially match or IDs that exactly match entries from this list will not be automated.'] = '' -- MISSING!
 
 L['ALT key'] = ALT_KEY
 L['CTRL key'] = CTRL_KEY

--- a/locale/itIT.lua
+++ b/locale/itIT.lua
@@ -10,13 +10,16 @@ local L = select(2, ...).L('itIT')
 
 -- L['Item Blocklist'] = '' -- MISSING!
 -- L['NPC Blocklist'] = '' -- MISSING!
+-- L['Title Blocklist'] = '' -- MISSING
 -- L['Block Item'] = '' -- MISSING!
 -- L['Block NPC'] = '' -- MISSING!
+-- L['Block Title']) = '' --MISSING!
 -- L['Quests containing items in this list will not be automated.'] = '' -- MISSING!
 -- L['Quests and dialogue from NPCs in this list will not be automated.'] = '' -- MISSING!
 
 -- L['Block a new item by ID'] = '' -- MISSING!
 -- L['Block a new NPC by ID'] = '' -- MISSING!
+-- L['Quests with titles that partially match or IDs that exactly match entries from this list will not be automated.'] = '' -- MISSING!
 
 L['ALT key'] = ALT_KEY
 L['CTRL key'] = CTRL_KEY

--- a/locale/koKR.lua
+++ b/locale/koKR.lua
@@ -10,13 +10,16 @@ L['Automatically pay Darkmoon Faire teleporting fees'] = '다크문 축제 순�
 
 -- L['Item Blocklist'] = '' -- MISSING!
 -- L['NPC Blocklist'] = '' -- MISSING!
+-- L['Title Blocklist'] = '' -- MISSING
 -- L['Block Item'] = '' -- MISSING!
 -- L['Block NPC'] = '' -- MISSING!
+-- L['Block Title']) = '' --MISSING!
 -- L['Quests containing items in this list will not be automated.'] = '' -- MISSING!
 -- L['Quests and dialogue from NPCs in this list will not be automated.'] = '' -- MISSING!
 
 -- L['Block a new item by ID'] = '' -- MISSING!
 -- L['Block a new NPC by ID'] = '' -- MISSING!
+-- L['Quests with titles that partially match or IDs that exactly match entries from this list will not be automated.'] = '' -- MISSING!
 
 L['ALT key'] = ALT_KEY
 L['CTRL key'] = CTRL_KEY

--- a/locale/ptBR.lua
+++ b/locale/ptBR.lua
@@ -10,13 +10,16 @@ L['Reverse the behaviour of the modifier key'] = 'Inverter o comportamento da te
 
 -- L['Item Blocklist'] = '' -- MISSING!
 -- L['NPC Blocklist'] = '' -- MISSING!
+-- L['Title Blocklist'] = '' -- MISSING
 -- L['Block Item'] = '' -- MISSING!
 -- L['Block NPC'] = '' -- MISSING!
+-- L['Block Title']) = '' --MISSING!
 -- L['Quests containing items in this list will not be automated.'] = '' -- MISSING!
 -- L['Quests and dialogue from NPCs in this list will not be automated.'] = '' -- MISSING!
 
 -- L['Block a new item by ID'] = '' -- MISSING!
 -- L['Block a new NPC by ID'] = '' -- MISSING!
+-- L['Quests with titles that partially match or IDs that exactly match entries from this list will not be automated.'] = '' -- MISSING!
 
 L['ALT key'] = ALT_KEY
 L['CTRL key'] = CTRL_KEY

--- a/locale/ruRU.lua
+++ b/locale/ruRU.lua
@@ -10,13 +10,16 @@ local L = select(2, ...).L('ruRU')
 
 -- L['Item Blocklist'] = '' -- MISSING!
 -- L['NPC Blocklist'] = '' -- MISSING!
+-- L['Title Blocklist'] = '' -- MISSING
 -- L['Block Item'] = '' -- MISSING!
 -- L['Block NPC'] = '' -- MISSING!
+-- L['Block Title']) = '' --MISSING!
 -- L['Quests containing items in this list will not be automated.'] = '' -- MISSING!
 -- L['Quests and dialogue from NPCs in this list will not be automated.'] = '' -- MISSING!
 
 -- L['Block a new item by ID'] = '' -- MISSING!
 -- L['Block a new NPC by ID'] = '' -- MISSING!
+-- L['Quests with titles that partially match or IDs that exactly match entries from this list will not be automated.'] = '' -- MISSING!
 
 L['ALT key'] = ALT_KEY
 L['CTRL key'] = CTRL_KEY

--- a/locale/zhCN.lua
+++ b/locale/zhCN.lua
@@ -10,13 +10,16 @@ L['Reverse the behaviour of the modifier key'] = '反转辅助键的行为（勾
 
 -- L['Item Blocklist'] = '' -- MISSING!
 -- L['NPC Blocklist'] = '' -- MISSING!
+-- L['Title Blocklist'] = '' -- MISSING
 -- L['Block Item'] = '' -- MISSING!
 -- L['Block NPC'] = '' -- MISSING!
+-- L['Block Title']) = '' --MISSING!
 -- L['Quests containing items in this list will not be automated.'] = '' -- MISSING!
 -- L['Quests and dialogue from NPCs in this list will not be automated.'] = '' -- MISSING!
 
 -- L['Block a new item by ID'] = '' -- MISSING!
 -- L['Block a new NPC by ID'] = '' -- MISSING!
+-- L['Quests with titles that partially match or IDs that exactly match entries from this list will not be automated.'] = '' -- MISSING!
 
 L['ALT key'] = ALT_KEY
 L['CTRL key'] = CTRL_KEY

--- a/locale/zhTW.lua
+++ b/locale/zhTW.lua
@@ -10,13 +10,16 @@ L['Reverse the behaviour of the modifier key'] = '反轉輔助鍵的行為（勾
 
 -- L['Item Blocklist'] = '' -- MISSING!
 -- L['NPC Blocklist'] = '' -- MISSING!
+-- L['Title Blocklist'] = '' -- MISSING
 -- L['Block Item'] = '' -- MISSING!
 -- L['Block NPC'] = '' -- MISSING!
+-- L['Block Title']) = '' --MISSING!
 -- L['Quests containing items in this list will not be automated.'] = '' -- MISSING!
 -- L['Quests and dialogue from NPCs in this list will not be automated.'] = '' -- MISSING!
 
 -- L['Block a new item by ID'] = '' -- MISSING!
 -- L['Block a new NPC by ID'] = '' -- MISSING!
+-- L['Quests with titles that partially match or IDs that exactly match entries from this list will not be automated.'] = '' -- MISSING!
 
 L['ALT key'] = ALT_KEY
 L['CTRL key'] = CTRL_KEY


### PR DESCRIPTION
Hey there @p3lim.  Thanks for continuing to work on this addon, it's saved me a ton of time over the years.   I implemented this title / questID based blocklist for myself midway through BFA and figured I would share it now that you're pushing out frequent updates again.  Also has a small bug fix for using the enter key in input boxes for quest items/npcs.  Hope this meets your approval.