### PR TITLE
Fixed edit box behavior when the enter key is pressed

### DIFF
--- a/config/OptionsPopups.lua
+++ b/config/OptionsPopups.lua
@@ -6,8 +6,8 @@ StaticPopupDialogs[addonName .. 'ItemBlocklistPopup'] = {
 	button1 = L['Accept'],
 	button2 = L['Cancel'],
 	hasEditBox = true,
-	EditBoxOnEnterPressed = function(self)
-		self.data.callback(self.data.pool, tonumber(strtrim(self.editBox:GetText())))
+	EditBoxOnEnterPressed = function(self, data)
+		data.callback(data.pool, tonumber(strtrim(self:GetText())))
 		self:GetParent():Hide()
 	end,
 	EditBoxOnEscapePressed = function(self)
@@ -51,8 +51,8 @@ StaticPopupDialogs[addonName .. 'NPCBlocklistPopup'] = {
 	button2 = L['Cancel'],
 	button3 = L['Target'],
 	hasEditBox = true,
-	EditBoxOnEnterPressed = function(self)
-		self.data.callback(self.data.pool, tonumber(strtrim(self.editBox:GetText())))
+	EditBoxOnEnterPressed = function(self, data)
+		data.callback(data.pool, tonumber(strtrim(self:GetText())))
 		self:GetParent():Hide()
 	end,
 	EditBoxOnEscapePressed = function(self)


### PR DESCRIPTION
As requested, I've moved this into it's own PR.  I'm not sure when these arguments changed, but it seems to be how Blizzard is doing things now (eg, [here](https://www.townlong-yak.com/framexml/live/StaticPopup.lua) is Blizzard's `StaticPopup.lua`).