### PR TITLE
Fix blocking quest by ID

### DIFF
--- a/settings.lua
+++ b/settings.lua
@@ -447,8 +447,15 @@ addon:RegisterSubCanvas(L['Quest Blocklist'], function(canvas)
 	end)
 
 	createAddButton(canvas, L['Block a quest by title or ID'], function(data)
-		QuickQuestBlocklistDB.quests[data] = true
-		list:AddData(data)
+	        local num = tonumber(data)
+	
+	        if num ~= nil then
+	            QuickQuestBlocklistDB.quests[num] = true
+	            list:AddData(num)
+	        else
+	            QuickQuestBlocklistDB.quests[data] = true
+	            list:AddData(data)
+	        end
 	end)
 end)
 


### PR DESCRIPTION
Adding a quest via ID it gets added as a string to the table, this tries to correct that.

I am not very good with LUA so perhaps you have a better solution to this.

This solution does fix it for me currently (I have been testing on TWW Beta servers)